### PR TITLE
Bump version to 1.1.0 in Directory.Build.props

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Authors>Victor Hugo Garcia Hernandez</Authors>
-    <VersionPrefix>1.0.0</VersionPrefix>
+    <VersionPrefix>1.1.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/vhugogarcia/xperience-community-cache-manager</PackageProjectUrl>


### PR DESCRIPTION
Updated the VersionPrefix property from 1.0.0 to 1.1.0 to prepare for a new release. No other changes were made.